### PR TITLE
fix: translate document links based on selected language

### DIFF
--- a/client/playwright/tests/documents-translation.spec.ts
+++ b/client/playwright/tests/documents-translation.spec.ts
@@ -1,0 +1,113 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Documents Page - Language Translation', () => {
+  test.beforeEach(async ({ page }) => {
+    // Clear localStorage to start fresh and set English as default
+    await page.goto('/docs');
+    await page.evaluate(() => {
+      localStorage.setItem('locale', 'en');
+    });
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+  });
+
+  test('should have document links with EN paths when language is English', async ({ page }) => {
+    // Language is already set to EN via beforeEach
+
+    // Verify document cards contain English URLs
+    const documentCards = page.locator('[data-testid="document-card"]');
+    const count = await documentCards.count();
+    expect(count).toBeGreaterThan(0);
+
+    // Check that PDF links use English URL patterns
+    const tournamentRulesLink = documentCards.filter({ hasText: 'Tournament Rules' });
+    await expect(tournamentRulesLink).toHaveAttribute('href', /\/cms2\//);
+    await expect(tournamentRulesLink).toHaveAttribute('href', /-en\.pdf$/);
+
+    const penaltyLink = documentCards.filter({ hasText: 'Penalty Guidelines' });
+    await expect(penaltyLink).toHaveAttribute('href', /\/cms2\//);
+    await expect(penaltyLink).toHaveAttribute('href', /-en\.pdf$/);
+  });
+
+  test('should update document links to PT paths when language is Portuguese', async ({ page }) => {
+    // Switch to Portuguese
+    await page.locator('[data-wizard-language]').click();
+    await page.getByRole('option', { name: 'PT' }).click();
+
+    // Wait for language change to take effect
+    await page.waitForTimeout(500);
+
+    // Verify document cards contain Portuguese URLs
+    const documentCards = page.locator('[data-testid="document-card"]');
+
+    // Check that PDF links use Portuguese URL patterns: /cms2-pt-br/ and -br.pdf
+    const tournamentRulesLink = documentCards.filter({ hasText: /Manual de Regras|Tournament Rules/ });
+    await expect(tournamentRulesLink).toHaveAttribute('href', /\/cms2-pt-br\//);
+    await expect(tournamentRulesLink).toHaveAttribute('href', /-br\.pdf$/);
+
+    const penaltyLink = documentCards.filter({ hasText: /Diretrizes de Penalidades|Penalty Guidelines/ });
+    await expect(penaltyLink).toHaveAttribute('href', /\/cms2-pt-br\//);
+    await expect(penaltyLink).toHaveAttribute('href', /-br\.pdf$/);
+  });
+
+  test('should switch links back to EN when switching from PT to EN', async ({ page }) => {
+    // Switch to Portuguese first
+    await page.locator('[data-wizard-language]').click();
+    await page.getByRole('option', { name: 'PT' }).click();
+    await page.waitForTimeout(500);
+
+    // Now switch back to English
+    await page.locator('[data-wizard-language]').click();
+    await page.getByRole('option', { name: 'EN' }).click();
+    await page.waitForTimeout(500);
+
+    // Verify document cards contain English URLs again
+    const documentCards = page.locator('[data-testid="document-card"]');
+
+    const tournamentRulesLink = documentCards.filter({ hasText: 'Tournament Rules' });
+    await expect(tournamentRulesLink).toHaveAttribute('href', /\/cms2\//);
+    await expect(tournamentRulesLink).toHaveAttribute('href', /-en\.pdf$/);
+  });
+
+  test('all PDF document links should update their cms path for PT', async ({ page }) => {
+    // Switch to Portuguese
+    await page.locator('[data-wizard-language]').click();
+    await page.getByRole('option', { name: 'PT' }).click();
+    await page.waitForTimeout(500);
+
+    // Get all document card hrefs
+    const documentCards = page.locator('[data-testid="document-card"]');
+    const count = await documentCards.count();
+
+    for (let i = 0; i < count; i++) {
+      const href = await documentCards.nth(i).getAttribute('href');
+      if (href && href.includes('pokemon.com/static-assets')) {
+        // All static-assets PDF links should use PT path
+        expect(href).toContain('/cms2-pt-br/');
+        // URLs end with either -br.pdf or _br.pdf depending on the original naming convention
+        expect(href).toMatch(/[_-]br\.pdf$/);
+      }
+    }
+  });
+
+  test('non-PDF links should not be affected by language change', async ({ page }) => {
+    // Switch to Portuguese
+    await page.locator('[data-wizard-language]').click();
+    await page.getByRole('option', { name: 'PT' }).click();
+    await page.waitForTimeout(500);
+
+    // The judgeball.com link should remain unchanged
+    const documentCards = page.locator('[data-testid="document-card"]');
+    const count = await documentCards.count();
+
+    let foundJudgeball = false;
+    for (let i = 0; i < count; i++) {
+      const href = await documentCards.nth(i).getAttribute('href');
+      if (href && href.includes('judgeball.com')) {
+        foundJudgeball = true;
+        expect(href).toBe('https://www.judgeball.com/guidebook/tcg/attack-steps/');
+      }
+    }
+    expect(foundJudgeball).toBe(true);
+  });
+});

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -7,38 +7,48 @@ interface Document {
 }
 
 const documents: Document[] = [
-  { 
-    key: 'tournamentRules', 
-    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-tournament-rules-handbook-en.pdf' 
+  {
+    key: 'tournamentRules',
+    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-tournament-rules-handbook-en.pdf'
   },
-  { 
-    key: 'penaltyGuidelines', 
-    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-penalty-guidelines-en.pdf' 
+  {
+    key: 'penaltyGuidelines',
+    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-penalty-guidelines-en.pdf'
   },
-  { 
-    key: 'rulebook', 
-    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/trading-card-game/rulebook/pfl_rulebook_en.pdf' 
+  {
+    key: 'rulebook',
+    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/trading-card-game/rulebook/pfl_rulebook_en.pdf'
   },
-  { 
-    key: 'bannedCards', 
-    url: 'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list' 
+  {
+    key: 'bannedCards',
+    url: 'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-banned-card-list'
   },
-  { 
-    key: 'tcgTournamentHandbook', 
-    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-tcg-tournament-handbook-en.pdf' 
+  {
+    key: 'tcgTournamentHandbook',
+    url: 'https://www.pokemon.com/static-assets/content-assets/cms2/pdf/play-pokemon/rules/play-pokemon-tcg-tournament-handbook-en.pdf'
   },
-  { 
-    key: 'promoLegality', 
-    url: 'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-promo-card-legality-status' 
+  {
+    key: 'promoLegality',
+    url: 'https://www.pokemon.com/us/play-pokemon/about/pokemon-tcg-promo-card-legality-status'
   },
-  { 
-    key: 'attackSteps', 
-    url: 'https://www.judgeball.com/guidebook/tcg/attack-steps/' 
+  {
+    key: 'attackSteps',
+    url: 'https://www.judgeball.com/guidebook/tcg/attack-steps/'
   },
 ];
 
+function getLocalizedUrl(url: string, language: string): string {
+  if (language === 'pt') {
+    return url
+      .replace('/cms2/', '/cms2-pt-br/')
+      .replace(/_en\.pdf$/, '_br.pdf')
+      .replace(/-en\.pdf$/, '-br.pdf');
+  }
+  return url;
+}
+
 export function DocumentsPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('light', { getInitialValueInEffect: true });
   const isDark = colorScheme === 'dark';
@@ -52,7 +62,7 @@ export function DocumentsPage() {
           key={doc.key}
           data-testid="document-card"
           component="a"
-          href={doc.url}
+          href={getLocalizedUrl(doc.url, i18n.language)}
           target="_blank"
           rel="noopener noreferrer"
           p="md"


### PR DESCRIPTION
## Summary
- Document links on the Documents page now dynamically update based on the selected language
- When switching to PT, URLs are transformed: `/cms2/` becomes `/cms2-pt-br/` and `-en.pdf`/`_en.pdf` become `-br.pdf`/`_br.pdf`
- Non-translatable links (e.g., judgeball.com, pokemon.com web pages) are left unchanged

Closes #1

## Test plan
- [x] Added 5 Playwright E2E tests in `documents-translation.spec.ts`
- [x] EN language: document links contain `/cms2/` and `-en.pdf` paths
- [x] PT language: document links update to `/cms2-pt-br/` and `-br.pdf` paths
- [x] Switching PT -> EN reverts links back to English URLs
- [x] All static-assets PDF links update their CMS path for PT
- [x] Non-PDF links (judgeball.com) remain unchanged
- [x] Full test suite (123 tests) passes with zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents page now displays localized links based on selected language
  * Document PDF links automatically update when switching to Portuguese
  * External guidebook links remain accessible across all language settings

* **Tests**
  * Added comprehensive test coverage for language-based URL translation on the Documents page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->