### PR TITLE
feat: add penalties registration tab

### DIFF
--- a/client/playwright/tests/penalties.spec.ts
+++ b/client/playwright/tests/penalties.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Penalties Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/penalties');
+    await page.evaluate(() => localStorage.removeItem('penalties'));
+    await page.reload();
+  });
+
+  test('should display Penalties tab in navigation', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: /penalties|penalidades|sanciones/i })).toBeVisible();
+  });
+
+  test('should display page title', async ({ page }) => {
+    await expect(page.getByRole('paragraph').filter({ hasText: /^Penalties$|^Penalidades$|^Sanciones$/ })).toBeVisible();
+  });
+
+  test('should display input fields for player/table, penalty type, and notes', async ({ page }) => {
+    await expect(page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i)).toBeVisible();
+    await expect(page.getByText(/penalty type|tipo de penalidade|tipo de sanción/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/notes|notas|observações/i)).toBeVisible();
+  });
+
+  test('should display ADD button', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /add|adicionar|agregar/i })).toBeVisible();
+  });
+
+  test('should add a new penalty', async ({ page }) => {
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 5 - John');
+    // Select penalty type
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /warning|advertência|advertencia/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Slow play');
+
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Should display the new penalty in the list
+    await expect(page.getByRole('cell', { name: 'Table 5 - John' })).toBeVisible();
+    await expect(page.getByRole('cell', { name: /warning|advertência|advertencia/i })).toBeVisible();
+    await expect(page.getByRole('cell', { name: 'Slow play' })).toBeVisible();
+  });
+
+  test('should clear inputs after adding a penalty', async ({ page }) => {
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 5 - John');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /caution|cuidado|precaución/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Minor issue');
+
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    await expect(page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i)).toHaveValue('');
+    await expect(page.getByPlaceholder(/notes|notas|observações/i)).toHaveValue('');
+  });
+
+  test('should add multiple penalties', async ({ page }) => {
+    // Add first penalty
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 1 - Alice');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /caution|cuidado|precaución/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Minor issue');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Add second penalty
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 3 - Bob');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /game loss|derrota|pérdida/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Deck error');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Both should be visible
+    await expect(page.getByText('Table 1 - Alice')).toBeVisible();
+    await expect(page.getByText('Table 3 - Bob')).toBeVisible();
+  });
+
+  test('should delete a penalty', async ({ page }) => {
+    // Add a penalty
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 5 - John');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /warning|advertência|advertencia/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Slow play');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Verify it's visible
+    await expect(page.getByText('Table 5 - John')).toBeVisible();
+
+    // Delete
+    await page.getByRole('button', { name: /delete|excluir|eliminar/i }).click();
+
+    // Should show empty state
+    await expect(page.getByText(/no penalties|nenhuma penalidade|sin sanciones/i)).toBeVisible();
+  });
+
+  test('should clear all penalties with reset button', async ({ page }) => {
+    // Add two penalties
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 1 - Alice');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /caution|cuidado|precaución/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Note 1');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 3 - Bob');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /warning|advertência|advertencia/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Note 2');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Click clear all
+    await page.getByRole('button', { name: /clear all|limpar tudo|limpiar todo/i }).click();
+
+    // Should show empty state
+    await expect(page.getByText(/no penalties|nenhuma penalidade|sin sanciones/i)).toBeVisible();
+  });
+
+  test('should persist penalties in localStorage', async ({ page }) => {
+    // Add penalty
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 5 - John');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /warning|advertência|advertencia/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Slow play');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Wait for penalty to appear
+    await expect(page.getByText('Table 5 - John')).toBeVisible();
+
+    // Verify localStorage has data
+    const storedData = await page.evaluate(() => localStorage.getItem('penalties'));
+    expect(storedData).toContain('Table 5 - John');
+    expect(storedData).toContain('Slow play');
+  });
+
+  test('should load penalties from localStorage on page reload', async ({ page }) => {
+    // Add penalty
+    await page.getByPlaceholder(/player.*table|jogador.*mesa|jugador.*mesa/i).fill('Table 7 - Carol');
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /caution|cuidado|precaución/i }).click();
+    await page.getByPlaceholder(/notes|notas|observações/i).fill('Minor infraction');
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Wait for it to appear and verify localStorage was saved
+    await expect(page.getByRole('cell', { name: 'Table 7 - Carol' })).toBeVisible();
+
+    // Navigate away and come back to simulate fresh component mount
+    await page.getByRole('tab', { name: /table judge/i }).click();
+    await page.getByRole('tab', { name: /penalties|penalidades|sanciones/i }).click();
+
+    // Should still be visible after loading from localStorage
+    await expect(page.getByRole('cell', { name: 'Table 7 - Carol' })).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('cell', { name: 'Minor infraction' })).toBeVisible();
+  });
+
+  test('should not add penalty with empty player/table field', async ({ page }) => {
+    await page.getByTestId('penalty-type-select').click();
+    await page.getByRole('option', { name: /warning|advertência|advertencia/i }).click();
+    await page.getByRole('button', { name: /add|adicionar|agregar/i }).click();
+
+    // Should show empty state (no penalty added)
+    await expect(page.getByText(/no penalties|nenhuma penalidade|sin sanciones/i)).toBeVisible();
+  });
+
+  test('should display all penalty type options', async ({ page }) => {
+    await page.getByTestId('penalty-type-select').click();
+
+    await expect(page.getByRole('option', { name: /caution|cuidado|precaución/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /warning|advertência|advertencia/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /prize card|carta de prêmio|carta de premio/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /game loss|derrota|pérdida/i })).toBeVisible();
+    await expect(page.getByRole('option', { name: /disqualification|desclassificação|descalificación/i })).toBeVisible();
+  });
+
+  test('should show empty state when no penalties are registered', async ({ page }) => {
+    await expect(page.getByText(/no penalties|nenhuma penalidade|sin sanciones/i)).toBeVisible();
+  });
+});

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import { TableJudgePage } from './pages/TableJudgePage';
 import RoundTimerPage from './pages/RoundTimerPage';
 import RoundTimerDisplayPage from './pages/RoundTimerDisplayPage';
 import TimeExtensionsPage from './pages/TimeExtensionsPage';
+import PenaltiesPage from './pages/PenaltiesPage';
 import { OnboardingWizardProvider } from './components/OnboardingWizard/OnboardingWizardContext';
 
 const colorSchemeManager = localStorageColorSchemeManager({ key: 'color-scheme' });
@@ -31,6 +32,7 @@ function App() {
             <Route path="/docs" element={<AppLayout><DocumentsPage /></AppLayout>} />
             <Route path="/round-timer" element={<AppLayout><RoundTimerPage /></AppLayout>} />
             <Route path="/time-extensions" element={<AppLayout><TimeExtensionsPage /></AppLayout>} />
+            <Route path="/penalties" element={<AppLayout><PenaltiesPage /></AppLayout>} />
           </Routes>
         </OnboardingWizardProvider>
       </BrowserRouter>

--- a/client/src/components/AppLayout.tsx
+++ b/client/src/components/AppLayout.tsx
@@ -97,6 +97,7 @@ export function AppLayout({ children }: AppLayoutProps) {
           <Tabs.Tab value="/deck-check">{t('tabs.deckCheck')}</Tabs.Tab>
           <Tabs.Tab value="/round-timer">{t('tabs.roundTimer')}</Tabs.Tab>
           <Tabs.Tab value="/time-extensions">{t('tabs.timeExtensions')}</Tabs.Tab>
+          <Tabs.Tab value="/penalties">{t('tabs.penalties')}</Tabs.Tab>
           <Tabs.Tab value="/docs">{t('tabs.documents')}</Tabs.Tab>
         </Tabs.List>
       </Tabs>

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -111,7 +111,8 @@
     "deckCheck": "Deck Check",
     "documents": "Documents",
     "roundTimer": "Round Timer",
-    "timeExtensions": "Extensions"
+    "timeExtensions": "Extensions",
+    "penalties": "Penalties"
   },
   "documents": {
     "title": "Official Documents",
@@ -198,6 +199,23 @@
     "save": "Save",
     "cancel": "Cancel",
     "noExtensions": "No extensions registered"
+  },
+  "penalties": {
+    "title": "Penalties",
+    "playerTablePlaceholder": "Player / Table",
+    "penaltyType": "Penalty Type",
+    "notesPlaceholder": "Notes",
+    "add": "ADD",
+    "clearAll": "CLEAR ALL",
+    "delete": "Delete",
+    "noPenalties": "No penalties registered",
+    "types": {
+      "caution": "Caution",
+      "warning": "Warning",
+      "prizeCard": "Prize Card",
+      "gameLoss": "Game Loss",
+      "disqualification": "Disqualification"
+    }
   },
   "credits": {
     "title": "Credits",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -111,7 +111,8 @@
     "deckCheck": "Deck Check",
     "documents": "Documentos",
     "roundTimer": "Timer de Ronda",
-    "timeExtensions": "Extensiones"
+    "timeExtensions": "Extensiones",
+    "penalties": "Sanciones"
   },
   "documents": {
     "title": "Documentos Oficiales",
@@ -198,6 +199,23 @@
     "save": "Guardar",
     "cancel": "Cancelar",
     "noExtensions": "Sin extensiones registradas"
+  },
+  "penalties": {
+    "title": "Sanciones",
+    "playerTablePlaceholder": "Jugador / Mesa",
+    "penaltyType": "Tipo de Sanción",
+    "notesPlaceholder": "Notas",
+    "add": "AGREGAR",
+    "clearAll": "LIMPIAR TODO",
+    "delete": "Eliminar",
+    "noPenalties": "Sin sanciones registradas",
+    "types": {
+      "caution": "Precaución",
+      "warning": "Advertencia",
+      "prizeCard": "Carta de Premio",
+      "gameLoss": "Pérdida de Juego",
+      "disqualification": "Descalificación"
+    }
   },
   "credits": {
     "title": "Créditos",

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -111,7 +111,8 @@
     "deckCheck": "Deck Check",
     "documents": "Documentos",
     "roundTimer": "Timer de Rodada",
-    "timeExtensions": "Extensões"
+    "timeExtensions": "Extensões",
+    "penalties": "Penalidades"
   },
   "documents": {
     "title": "Documentos Oficiais",
@@ -198,6 +199,23 @@
     "save": "Salvar",
     "cancel": "Cancelar",
     "noExtensions": "Nenhuma extensão registrada"
+  },
+  "penalties": {
+    "title": "Penalidades",
+    "playerTablePlaceholder": "Jogador / Mesa",
+    "penaltyType": "Tipo de Penalidade",
+    "notesPlaceholder": "Observações",
+    "add": "ADICIONAR",
+    "clearAll": "LIMPAR TUDO",
+    "delete": "Excluir",
+    "noPenalties": "Nenhuma penalidade registrada",
+    "types": {
+      "caution": "Cuidado",
+      "warning": "Advertência",
+      "prizeCard": "Carta de Prêmio",
+      "gameLoss": "Derrota",
+      "disqualification": "Desclassificação"
+    }
   },
   "credits": {
     "title": "Créditos",

--- a/client/src/pages/PenaltiesPage.tsx
+++ b/client/src/pages/PenaltiesPage.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from 'react';
+import { Stack, Paper, TextInput, Button, Group, Text, Select, Table, ActionIcon } from '@mantine/core';
+import { useTranslation } from 'react-i18next';
+
+const IconTrash = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+interface Penalty {
+  id: string;
+  playerTable: string;
+  type: string;
+  notes: string;
+  timestamp: string;
+}
+
+const PENALTY_TYPE_KEYS = ['caution', 'warning', 'prizeCard', 'gameLoss', 'disqualification'] as const;
+
+function loadPenalties(): Penalty[] {
+  try {
+    const saved = localStorage.getItem('penalties');
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return [];
+}
+
+export default function PenaltiesPage() {
+  const { t } = useTranslation();
+  const [penalties, setPenalties] = useState<Penalty[]>(loadPenalties);
+  const [playerTable, setPlayerTable] = useState('');
+  const [penaltyType, setPenaltyType] = useState<string | null>(null);
+  const [notes, setNotes] = useState('');
+
+  const penaltyTypeOptions = PENALTY_TYPE_KEYS.map((key) => ({
+    value: key,
+    label: t(`penalties.types.${key}`),
+  }));
+
+  // Save to localStorage whenever penalties change
+  useEffect(() => {
+    localStorage.setItem('penalties', JSON.stringify(penalties));
+  }, [penalties]);
+
+  const handleAdd = () => {
+    if (!playerTable.trim()) {
+      return;
+    }
+
+    const newPenalty: Penalty = {
+      id: Date.now().toString(),
+      playerTable: playerTable.trim(),
+      type: penaltyType || 'caution',
+      notes: notes.trim(),
+      timestamp: new Date().toLocaleTimeString(),
+    };
+
+    setPenalties((prev) => [...prev, newPenalty]);
+    setPlayerTable('');
+    setPenaltyType(null);
+    setNotes('');
+  };
+
+  const handleDelete = (id: string) => {
+    setPenalties((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  const handleClearAll = () => {
+    setPenalties([]);
+  };
+
+  return (
+    <Stack gap="lg" p="md">
+      <Paper shadow="xs" p="md" withBorder>
+        <Stack gap="md">
+          <Text size="lg" fw={600}>
+            {t('penalties.title')}
+          </Text>
+
+          <TextInput
+            placeholder={t('penalties.playerTablePlaceholder')}
+            value={playerTable}
+            onChange={(e) => setPlayerTable(e.target.value)}
+          />
+
+          <Select
+            label={t('penalties.penaltyType')}
+            data={penaltyTypeOptions}
+            value={penaltyType}
+            onChange={setPenaltyType}
+            data-testid="penalty-type-select"
+            clearable
+          />
+
+          <TextInput
+            placeholder={t('penalties.notesPlaceholder')}
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+          />
+
+          <Button onClick={handleAdd} fullWidth>
+            {t('penalties.add')}
+          </Button>
+        </Stack>
+      </Paper>
+
+      {penalties.length > 0 && (
+        <Button color="red" variant="light" onClick={handleClearAll} fullWidth>
+          {t('penalties.clearAll')}
+        </Button>
+      )}
+
+      <Stack gap="md">
+        {penalties.length === 0 ? (
+          <Paper shadow="xs" p="md" withBorder>
+            <Text ta="center" c="dimmed">
+              {t('penalties.noPenalties')}
+            </Text>
+          </Paper>
+        ) : (
+          <Paper shadow="xs" p="md" withBorder>
+            <Table>
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>{t('penalties.playerTablePlaceholder')}</Table.Th>
+                  <Table.Th>{t('penalties.penaltyType')}</Table.Th>
+                  <Table.Th>{t('penalties.notesPlaceholder')}</Table.Th>
+                  <Table.Th w={60} style={{ textAlign: 'right' }}></Table.Th>
+                </Table.Tr>
+              </Table.Thead>
+              <Table.Tbody>
+                {penalties.map((penalty) => (
+                  <Table.Tr key={penalty.id}>
+                    <Table.Td>{penalty.playerTable}</Table.Td>
+                    <Table.Td>{t(`penalties.types.${penalty.type}`)}</Table.Td>
+                    <Table.Td>{penalty.notes}</Table.Td>
+                    <Table.Td>
+                      <Group gap="xs" justify="flex-end">
+                        <ActionIcon
+                          color="red"
+                          variant="light"
+                          onClick={() => handleDelete(penalty.id)}
+                          aria-label={t('penalties.delete')}
+                        >
+                          <IconTrash />
+                        </ActionIcon>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Paper>
+        )}
+      </Stack>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- Add new **Penalties** registration tab for Pokemon TCG tournament judges (Closes #3)
- Penalty form with player/table input, penalty type selector (Caution, Warning, Prize Card, Game Loss, Disqualification), and notes field
- Penalties list with individual delete and clear-all functionality
- Full localStorage persistence (survives page reloads and tab switching)
- Complete i18n support for English, Portuguese, and Spanish
- 14 Playwright E2E tests covering navigation, form submission, validation, persistence, and empty states

## Test plan
- [x] Penalties tab visible in navigation bar
- [x] Can register a new penalty with player/table, type, and notes
- [x] Form clears after submission
- [x] Can register multiple penalties
- [x] Can delete individual penalties
- [x] Can clear all penalties at once
- [x] Penalties persist in localStorage
- [x] Penalties survive tab switching (localStorage reload)
- [x] Empty player/table field prevents submission
- [x] All 5 penalty types available in dropdown
- [x] Empty state message shown when no penalties registered
- [x] All 132 existing tests still pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)