### PR TITLE
feat: add penalty disclaimer and CSV export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to Judge Helper will be documented in this file.
+
+This project follows [Semantic Versioning](https://semver.org/). See [VERSIONING.md](VERSIONING.md) for the full versioning strategy.
+
+---
+
+## [1.0.0] - 2026-04-08
+
+First stable release of Pokemon TCG Judge Helper. Includes all core judging tools, internationalization, and PWA support.
+
+### Features
+
+- **Penalties Tab** — Register penalties during a tournament with official TCG infraction categories (Gameplay Errors, Marked Cards, Deck Errors, Pace of Play, Tardiness, Unsporting Conduct, Cheating). Auto-fills the recommended penalty tier when selecting an infraction. Search and filter by player name. ([#12](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/12))
+- **Penalty CSV Export** — Export all logged penalties to a CSV file (Round, Player, Infraction, Penalty) sorted by round. Filename includes the current date (`penalties_YYYY-MM-DD.csv`). Headers follow the active language. ([#15](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/15))
+- **Penalty Disclaimer** — Disclaimer note under Penalty Guidelines in the Documents tab clarifying that suggestions follow rulebook recommendations but may be escalated or de-escalated based on context. ([#15](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/15))
+- **Time Extension Categories** — Categorize time extensions (Judge Call, Deck Check, Other) when logging them. Categories are displayed in the extensions list and persisted to localStorage. ([#9](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/9))
+- **Onboarding Wizard Steps** — Added onboarding wizard steps for the new time extension category feature. Removed the deprecated recommended extensions table. ([#9](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/9))
+- **Localized Document Links** — Document links in the Documents tab now point to Portuguese versions when PT is the active language. ([#8](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/8))
+
+### Fixes
+
+- **Onboarding Redirect** — Returning users are no longer redirected to the onboarding screen on every visit. ([#11](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/11))
+- **Tab Layout** — Navigation tabs arranged in a balanced 3/3 layout instead of 4/2 for better spacing on mobile.
+- **CSV Safety** — CSV export avoids state mutation (`[...penalties].sort()`), uses local date instead of UTC for the filename, and sanitizes fields against spreadsheet formula injection. ([#15](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/15))
+- **Mobile Layout** — Export CSV and Clear All buttons stack vertically for proper display on 375px screens. ([#15](https://github.com/FellipeGiulianoDuarte/judge-helper/pull/15))
+
+### Baseline (from pre-release)
+
+These features existed before the staging cycle and ship as part of v1.0.0:
+
+- **Table Judge** — Track player actions (Supporter, Energy, Stadium, Retreat, Other), turn timer with pace calculation, prize counter, turn history, and autostart options.
+- **Deck Check** — Card counting tool for Pokemon, Trainer, and Energy cards with +1/+2/+3/+4 increments, undo, and reset. Visual indicator at 60 cards.
+- **Round Timer** — Configurable countdown with BO1/BO3/Top Cut presets, pause/reset, color-coded remaining time, and a full-screen display mode.
+- **Time Extensions** — Log time extensions per table/round with edit and delete.
+- **Documents** — Quick-access links to official Pokemon TCG documents (Rulebook, Tournament Handbook, Penalty Guidelines, Banned Card List, Promo Legality, Attack Steps).
+- **Onboarding Wizard** — Interactive first-time tutorial highlighting each feature.
+- **Internationalization** — Full support for English, Portuguese, and Spanish.
+- **Dark Mode** — System-aware theme toggle.
+- **PWA** — Installable on mobile, works offline, localStorage persistence.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,82 @@
+# Versioning Strategy
+
+Judge Helper follows [Semantic Versioning 2.0.0](https://semver.org/) adapted for a client-side PWA with no public API.
+
+## Version Format
+
+```
+MAJOR.MINOR.PATCH
+```
+
+| Segment | Bump when... | Examples |
+|---------|-------------|----------|
+| **MAJOR** | Breaking changes to user-facing behavior: features removed, data format changes that invalidate localStorage, or workflows that fundamentally change. | Removing the Penalties tab, changing localStorage schema without migration, redesigning navigation so existing muscle memory breaks. |
+| **MINOR** | New features or meaningful enhancements that are backward-compatible. Users get new functionality without losing anything. | Adding a new tab, CSV export, new infraction categories, new language support, onboarding steps for a new feature. |
+| **PATCH** | Bug fixes, performance improvements, translation corrections, and cosmetic adjustments that don't change functionality. | Fixing UTC date in filename, layout fixes for mobile, formula injection protection, fixing onboarding redirect. |
+
+## Branch Workflow
+
+```
+feature/fix branch  →  staging  →  main
+                         ↑           ↑
+                      QA/test     production release
+```
+
+| Branch | Purpose | Deploys to |
+|--------|---------|------------|
+| `main` | Stable, tagged releases only. | Production (Vercel) |
+| `staging` | Integration branch. All feature/fix branches merge here first. | Vercel preview |
+| `feat/*`, `fix/*` | Short-lived branches for individual changes. | Vercel preview (per-PR) |
+
+- All work targets `staging` via PR.
+- When staging is stable and ready, merge `staging → main` and tag the release.
+- Never push directly to `main`.
+
+## Release Process
+
+1. **Confirm staging is stable** — all Playwright tests pass, Vercel preview looks good.
+2. **Update version** in `client/package.json`.
+3. **Update CHANGELOG.md** — add a new section with the version, date, and categorized changes.
+4. **Merge staging → main** via PR.
+5. **Tag the release** on main:
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+6. **Create a GitHub Release** from the tag, copying the changelog entry as the body.
+
+## Changelog Convention
+
+Each version entry in `CHANGELOG.md` groups changes under:
+
+- **Features** — new user-facing functionality (`feat:` commits)
+- **Fixes** — bug fixes and corrections (`fix:` commits)
+- **Refactors** — internal improvements with no user-facing change (`refactor:` commits)
+- **Docs** — documentation-only changes (`docs:` commits)
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add penalties registration tab
+fix: prevent onboarding redirect for returning users
+refactor: remove recommended extensions table
+docs: update contributing guide
+```
+
+The commit prefix determines which changelog section the change falls under and helps decide the version bump:
+
+| Prefix | Changelog section | Minimum bump |
+|--------|-------------------|-------------|
+| `feat:` | Features | MINOR |
+| `fix:` | Fixes | PATCH |
+| `refactor:` | Refactors | PATCH |
+| `docs:` | Docs | PATCH |
+| `BREAKING CHANGE:` | (noted in Features/Fixes) | MAJOR |
+
+## When in Doubt
+
+- If it adds something new the user can see or interact with → **MINOR**.
+- If it fixes something that was broken or improves existing behavior → **PATCH**.
+- If it removes or fundamentally changes how an existing feature works → **MAJOR**.

--- a/client/src/i18n/locales/en.json
+++ b/client/src/i18n/locales/en.json
@@ -134,6 +134,7 @@
     "title": "Official Documents",
     "tournamentRules": "Tournament Rules Handbook",
     "penaltyGuidelines": "Penalty Guidelines",
+    "penaltyDisclaimer": "Penalty suggestions follow the official rulebook recommendations but may be escalated or de-escalated based on context and investigation.",
     "rulebook": "TCG Rulebook (PDF)",
     "bannedCards": "TCG Banned Card List",
     "tcgTournamentHandbook": "TCG Tournament Handbook",
@@ -242,7 +243,9 @@
     "confirmClearTitle": "Confirm Clear All",
     "confirmClearMessage": "Are you sure you want to clear all penalty records?",
     "confirm": "Confirm",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "exportCsv": "Export CSV",
+    "player": "Player"
   },
   "credits": {
     "title": "Credits",

--- a/client/src/i18n/locales/es.json
+++ b/client/src/i18n/locales/es.json
@@ -134,6 +134,7 @@
     "title": "Documentos Oficiales",
     "tournamentRules": "Manual de Reglas de Torneo",
     "penaltyGuidelines": "Directrices de Penalización",
+    "penaltyDisclaimer": "Las sugerencias de penalización siguen las recomendaciones oficiales del reglamento, pero pueden ser agravadas o atenuadas según el contexto y la investigación.",
     "rulebook": "Libro de Reglas TCG (PDF)",
     "bannedCards": "Lista de Cartas Prohibidas TCG",
     "tcgTournamentHandbook": "Manual de Torneo TCG",
@@ -242,7 +243,9 @@
     "confirmClearTitle": "Confirmar Limpieza",
     "confirmClearMessage": "¿Está seguro de que desea borrar todos los registros de penalización?",
     "confirm": "Confirmar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "exportCsv": "Exportar CSV",
+    "player": "Jugador"
   },
   "credits": {
     "title": "Créditos",

--- a/client/src/i18n/locales/pt.json
+++ b/client/src/i18n/locales/pt.json
@@ -134,6 +134,7 @@
     "title": "Documentos Oficiais",
     "tournamentRules": "Manual de Regras de Torneio",
     "penaltyGuidelines": "Diretrizes de Penalidades",
+    "penaltyDisclaimer": "As sugestões de penalidade seguem as recomendações oficiais do livro de regras, mas podem ser agravadas ou atenuadas conforme o contexto e a investigação.",
     "rulebook": "Livro de Regras TCG (PDF)",
     "bannedCards": "Lista de Cartas Banidas TCG",
     "tcgTournamentHandbook": "Manual de Torneio TCG",
@@ -242,7 +243,9 @@
     "confirmClearTitle": "Confirmar Limpeza",
     "confirmClearMessage": "Tem certeza que deseja limpar todos os registros de penalidade?",
     "confirm": "Confirmar",
-    "cancel": "Cancelar"
+    "cancel": "Cancelar",
+    "exportCsv": "Exportar CSV",
+    "player": "Jogador"
   },
   "credits": {
     "title": "Créditos",

--- a/client/src/pages/DocumentsPage.tsx
+++ b/client/src/pages/DocumentsPage.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Stack, Paper, Text, useMantineTheme, useComputedColorScheme } from '@mantine/core';
 
@@ -58,28 +59,34 @@ export function DocumentsPage() {
   return (
     <Stack gap="sm" p="md" data-wizard-documents>
       {documents.map((doc) => (
-        <Paper
-          key={doc.key}
-          data-testid="document-card"
-          component="a"
-          href={getLocalizedUrl(doc.url, i18n.language)}
-          target="_blank"
-          rel="noopener noreferrer"
-          p="md"
-          withBorder
-          style={{
-            minHeight: 56,
-            display: 'flex',
-            alignItems: 'center',
-            textDecoration: 'none',
-            cursor: 'pointer',
-            backgroundColor: cardBackground,
-          }}
-        >
-          <Text fw={500} data-testid="document-card-text" style={{ color: textColor }}>
-            {t(`documents.${doc.key}`)}
-          </Text>
-        </Paper>
+        <React.Fragment key={doc.key}>
+          <Paper
+            data-testid="document-card"
+            component="a"
+            href={getLocalizedUrl(doc.url, i18n.language)}
+            target="_blank"
+            rel="noopener noreferrer"
+            p="md"
+            withBorder
+            style={{
+              minHeight: 56,
+              display: 'flex',
+              alignItems: 'center',
+              textDecoration: 'none',
+              cursor: 'pointer',
+              backgroundColor: cardBackground,
+            }}
+          >
+            <Text fw={500} data-testid="document-card-text" style={{ color: textColor }}>
+              {t(`documents.${doc.key}`)}
+            </Text>
+          </Paper>
+          {doc.key === 'penaltyGuidelines' && (
+            <Text size="xs" c="dimmed" fs="italic" px="xs" mt={-4}>
+              {t('documents.penaltyDisclaimer')}
+            </Text>
+          )}
+        </React.Fragment>
       ))}
     </Stack>
   );

--- a/client/src/pages/PenaltiesPage.tsx
+++ b/client/src/pages/PenaltiesPage.tsx
@@ -3,6 +3,14 @@ import { Stack, Paper, TextInput, Button, Group, Text, Select, Textarea, Table, 
 import { useTranslation } from 'react-i18next';
 
 // Simple SVG icons
+const IconDownload = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="7 10 12 15 17 10" />
+    <line x1="12" y1="15" x2="12" y2="3" />
+  </svg>
+);
+
 const IconTrash = () => (
   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <polyline points="3 6 5 6 21 6" />
@@ -133,6 +141,42 @@ export default function PenaltiesPage() {
     setConfirmClearOpen(false);
   };
 
+  const handleExportCsv = () => {
+    if (penalties.length === 0) return;
+
+    const escapeCsv = (val: string) => {
+      if (val.includes(',') || val.includes('"') || val.includes('\n')) {
+        return `"${val.replace(/"/g, '""')}"`;
+      }
+      return val;
+    };
+
+    const header = [
+      t('penalties.round'),
+      t('penalties.player'),
+      t('penalties.infraction'),
+      t('penalties.penaltyApplied'),
+    ].join(',');
+
+    const rows = penalties
+      .sort((a, b) => a.round - b.round)
+      .map(p =>
+        [String(p.round), p.playerName, p.infraction, p.penaltyApplied]
+          .map(escapeCsv)
+          .join(',')
+      );
+
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    const today = new Date().toISOString().slice(0, 10);
+    link.download = `penalties_${today}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   // Build grouped select data for infractions
   const infractionSelectData = (() => {
     const groups: Record<string, { value: string; label: string }[]> = {};
@@ -237,16 +281,24 @@ export default function PenaltiesPage() {
         onChange={(e) => setSearchQuery(e.target.value)}
       />
 
-      {/* Clear All button (only when there are penalties) */}
+      {/* Export CSV + Clear All (only when there are penalties) */}
       {penalties.length > 0 && (
-        <Button
-          variant="outline"
-          color="red"
-          onClick={() => setConfirmClearOpen(true)}
-          fullWidth
-        >
-          {t('penalties.clearAll')}
-        </Button>
+        <Group grow gap="sm">
+          <Button
+            variant="light"
+            leftSection={<IconDownload />}
+            onClick={handleExportCsv}
+          >
+            {t('penalties.exportCsv')}
+          </Button>
+          <Button
+            variant="outline"
+            color="red"
+            onClick={() => setConfirmClearOpen(true)}
+          >
+            {t('penalties.clearAll')}
+          </Button>
+        </Group>
       )}
 
       {/* Penalty History */}

--- a/client/src/pages/PenaltiesPage.tsx
+++ b/client/src/pages/PenaltiesPage.tsx
@@ -145,10 +145,12 @@ export default function PenaltiesPage() {
     if (penalties.length === 0) return;
 
     const escapeCsv = (val: string) => {
-      if (val.includes(',') || val.includes('"') || val.includes('\n')) {
-        return `"${val.replace(/"/g, '""')}"`;
+      let s = String(val);
+      if (/^[=+\-@]/.test(s)) s = `'${s}`;
+      if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return `"${s.replace(/"/g, '""')}"`;
       }
-      return val;
+      return s;
     };
 
     const header = [
@@ -158,7 +160,7 @@ export default function PenaltiesPage() {
       t('penalties.penaltyApplied'),
     ].join(',');
 
-    const rows = penalties
+    const rows = [...penalties]
       .sort((a, b) => a.round - b.round)
       .map(p =>
         [String(p.round), p.playerName, p.infraction, p.penaltyApplied]
@@ -171,7 +173,8 @@ export default function PenaltiesPage() {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;
-    const today = new Date().toISOString().slice(0, 10);
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     link.download = `penalties_${today}.csv`;
     link.click();
     URL.revokeObjectURL(url);
@@ -283,11 +286,12 @@ export default function PenaltiesPage() {
 
       {/* Export CSV + Clear All (only when there are penalties) */}
       {penalties.length > 0 && (
-        <Group grow gap="sm">
+        <Stack gap="sm">
           <Button
             variant="light"
             leftSection={<IconDownload />}
             onClick={handleExportCsv}
+            fullWidth
           >
             {t('penalties.exportCsv')}
           </Button>
@@ -295,10 +299,11 @@ export default function PenaltiesPage() {
             variant="outline"
             color="red"
             onClick={() => setConfirmClearOpen(true)}
+            fullWidth
           >
             {t('penalties.clearAll')}
           </Button>
-        </Group>
+        </Stack>
       )}
 
       {/* Penalty History */}


### PR DESCRIPTION
## Summary
- Add disclaimer note under Penalty Guidelines in Documents page (EN/PT/ES) clarifying penalties follow rulebook recommendations but may be escalated/de-escalated based on context
- Add Export CSV button to Penalties page to download all logged penalties
- CSV includes Round, Player, Infraction, Penalty columns sorted by round
- Filename includes today's date (`penalties_YYYY-MM-DD.csv`)

## Test plan
- [ ] Verify disclaimer appears below Penalty Guidelines card in Documents tab
- [ ] Switch languages (EN/PT/ES) and verify disclaimer translates
- [ ] Log a few penalties, click Export CSV, verify file downloads with correct columns and date in filename
- [ ] Verify CSV headers match the active language
- [ ] Verify Export CSV button only appears when penalties exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export functionality to the Penalties page with download support.
  * Penalty disclaimer now displayed on the Documents page for penalty guidelines.

* **Chores**
  * Updated and expanded localization strings for English, Spanish, and Portuguese languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->